### PR TITLE
Remove -Wpedantic

### DIFF
--- a/STEventSource.xcodeproj/project.pbxproj
+++ b/STEventSource.xcodeproj/project.pbxproj
@@ -798,7 +798,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = STEventSource/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -821,7 +820,6 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = STEventSource/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -860,7 +858,6 @@
 		2CE477B71CBE7C9400ED7149 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				GCC_WARN_PEDANTIC = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = STEventSource;
@@ -876,7 +873,6 @@
 		2CE477B81CBE7C9400ED7149 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				GCC_WARN_PEDANTIC = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = STEventSource;
@@ -919,7 +915,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = STEventSource/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -945,7 +940,6 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_VERSION = A;
-				GCC_WARN_PEDANTIC = YES;
 				INFOPLIST_FILE = STEventSource/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -994,7 +988,6 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
-				GCC_WARN_PEDANTIC = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = STEventSource;
 				SDKROOT = macosx;
@@ -1010,7 +1003,6 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				EXECUTABLE_PREFIX = lib;
-				GCC_WARN_PEDANTIC = YES;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = STEventSource;
 				SDKROOT = macosx;


### PR DESCRIPTION
`NSAssert(expr, desc)` falls afoul of a pedantic warning about not providing a third argument to the variadic macro in `Release` builds. 😐 
